### PR TITLE
Fix broken react-dom

### DIFF
--- a/chapter9/reactd3/package.json
+++ b/chapter9/reactd3/package.json
@@ -15,7 +15,7 @@
     "d3-shape": "1.0.3",
     "d3-svg-legend": "2.15.0",
     "d3-transition": "1.0.3",
-    "react": "^15.3.2",
+    "react": "15.3.2",
     "react-dom": "15.3.2"
   },
   "scripts": {


### PR DESCRIPTION
After running `npm install` and `npm start`, I faced an error with react-dom.

```
Failed to compile.

Error in ./~/react-dom/index.js
Module not found: 'react/lib/ReactDOM' in /home/curran/repos/d3_in_action_2/chapter9/reactd3/node_modules/react-dom

 @ ./~/react-dom/index.js 3:17-46
```

My guess is that this was due to a newer version of React paired with an older version of React-Dom. The error went away when I pinned the React version in `package.json`. This is the only change in this PR.