### PR TITLE
change .style("id",...) to .attr("id",...)

### DIFF
--- a/chapter4/4_22.html
+++ b/chapter4/4_22.html
@@ -56,7 +56,7 @@
               .curve(d3.curveCardinal);
             d3.select("svg")
               .append("path")
-                .style("id", `${key} Area`)
+                .attr("id", `${key}Area`)
                 .attr("d", movieArea(data));
           }
         });


### PR DESCRIPTION
I changed the "id" definition from a .style() to a .attr(). I wasn't getting an id on my paths with the .style() method. 