### PR TITLE
Chapter 3 transition fixes

### DIFF
--- a/chapter3/3_06.html
+++ b/chapter3/3_06.html
@@ -1,14 +1,3 @@
-<!-- 
-Hello,
-
-I was not able to see transitions (i.e when clicking buttons) for examples 3_06.html - 3_15.html.
-I noticed that 3_16.html did animate transitions for button clicks, so I looked to see what the difference was, and noticed inside the buttonClick method, there is a transition defined that is not present in the afore-mentioned examples:
-
-`d3.selectAll("g.overallG").select("circle")**.transition().duration(1000)**`
-
-When I added this transition to example 3_06.html, I was able to see transitions for button clicks, which I think was the original intention.
- -->
-
 <!doctype html>
 <html>
   <head>

--- a/chapter3/3_06.html
+++ b/chapter3/3_06.html
@@ -1,3 +1,14 @@
+<!-- 
+Hello,
+
+I was not able to see transitions (i.e when clicking buttons) for examples 3_06.html - 3_15.html.
+I noticed that 3_16.html did animate transitions for button clicks, so I looked to see what the difference was, and noticed inside the buttonClick method, there is a transition defined that is not present in the afore-mentioned examples:
+
+`d3.selectAll("g.overallG").select("circle")**.transition().duration(1000)**`
+
+When I added this transition to example 3_06.html, I was able to see transitions for button clicks, which I think was the original intention.
+ -->
+
 <!doctype html>
 <html>
   <head>
@@ -92,7 +103,7 @@
           var radiusScale = d3.scaleLinear()
             .domain([ 0, maxValue ]).range([ 2, 20 ]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .attr("r", d => radiusScale(d[datapoint]));
         }
       }

--- a/chapter3/3_09.html
+++ b/chapter3/3_09.html
@@ -100,7 +100,7 @@
           var radiusScale = d3.scaleLinear()
             .domain([ 0, maxValue ]).range([ 2, 20 ]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .attr("r", d => radiusScale(d[datapoint]));
         }
       }

--- a/chapter3/3_10.html
+++ b/chapter3/3_10.html
@@ -105,7 +105,7 @@
           var radiusScale = d3.scaleLinear()
             .domain([ 0, maxValue ]).range([ 2, 20 ]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
             .attr("r", d => radiusScale(d[datapoint]));
         }
       }

--- a/chapter3/3_11.html
+++ b/chapter3/3_11.html
@@ -102,7 +102,7 @@
           var radiusScale = d3.scaleLinear()
             .domain([ 0, maxValue ]).range([ 2, 20 ]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
             .attr("r", d => radiusScale(d[datapoint]));
         }
       }

--- a/chapter3/3_12.html
+++ b/chapter3/3_12.html
@@ -83,12 +83,9 @@
           var ybRamp = d3.scaleLinear()
             .domain([0,maxValue]).range(["blue", "yellow"]);
 
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .attr("r", d => radiusScale(d[datapoint]))
               .style("fill", d => ybRamp(d[datapoint]));
-
-          d3.selectAll("g.overallG").select("circle")
-              .attr("r", d => radiusScale(d[datapoint]))
         }
       }
     </script>

--- a/chapter3/3_13.html
+++ b/chapter3/3_13.html
@@ -81,12 +81,9 @@
             .interpolate(d3.interpolateHsl)
             .domain([0,maxValue]).range(["blue", "yellow"]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
             .attr("r", d => radiusScale(d[datapoint]))
             .style("fill", d => ybRamp(d[datapoint]));
-          
-          d3.selectAll("g.overallG").select("circle")
-            .attr("r", d => radiusScale(d[datapoint]));
         }
       }
     </script>

--- a/chapter3/3_14.html
+++ b/chapter3/3_14.html
@@ -84,12 +84,9 @@
             .interpolate(d3.interpolateHcl)
             .domain([0,maxValue]).range(["blue", "yellow"]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .attr("r", d => radiusScale(d[datapoint]))
-              .style("fill", d => ybRamp(d[datapoint]));
-          
-          d3.selectAll("g.overallG").select("circle")
-              .attr("r", d => radiusScale(d[datapoint]));
+              .style("fill", d => ybRamp(d[datapoint]));          
         }
       }
     </script>

--- a/chapter3/3_15.html
+++ b/chapter3/3_15.html
@@ -84,12 +84,9 @@
             .interpolate(d3.interpolateLab)
             .domain([0,maxValue]).range(["blue", "yellow"]);
           
-          d3.selectAll("g.overallG").select("circle")
+          d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .attr("r", d => radiusScale(d[datapoint]))
               .style("fill", d => ybRamp(d[datapoint]));
-          
-          d3.selectAll("g.overallG").select("circle")
-              .attr("r", d => radiusScale(d[datapoint]));
         }
       }
     </script>

--- a/chapter3/3_24.html
+++ b/chapter3/3_24.html
@@ -103,7 +103,11 @@
             .range(["#5eafc6", "#FE9922", "#93C464", "#fcbc34" ]);
           
           d3.selectAll("path")
-              .style("fill", p => fourColorScale(p.region))
+              .style("fill", p => {
+                if (p) {
+                   fourColorScale(p.region);
+                 }
+              })
               .style("stroke", "black").style("stroke-width", "2px");
         }
       }


### PR DESCRIPTION
Hello,

I was not able to see transitions (i.e when clicking buttons) for examples 3_06.html - 3_15.html.
I noticed that 3_16.html did animate transitions for button clicks, so I looked to see what the difference was, and noticed inside the buttonClick method, there is a transition defined that is not present in the afore-mentioned examples:

`d3.selectAll("g.overallG").select("circle")**.transition().duration(1000)**`

When I added this transition to example 3_06.html, I was able to see transitions for button clicks, which I think was the original intention.

I also fixed a reference error with 3_24.html for a path without worldcup.csv data