### PR TITLE
fix region label for USA [CAF -> CONCACAF] + prevent svg icon cloning for SVG g element

### DIFF
--- a/chapter3/3_16.html
+++ b/chapter3/3_16.html
@@ -31,10 +31,10 @@
       <svg style="width:500px;height:500px;" ></svg>
     </div>
     <div id="controls" ></div>
-    
+
     <script>
       d3.csv("../data/worldcup.csv", data => overallTeamViz(data));
-      
+
       function overallTeamViz(incomingData) {
         d3.select("svg")
           .append("g")
@@ -46,9 +46,9 @@
           .append("g")
             .attr("class", "overallG")
             .attr("transform", (d, i) =>`translate(${(i * 50)}, 0)`);
-        
+
         var teamG = d3.selectAll("g.overallG");
-        
+
         teamG
           .append("circle").attr("r", 0)
           .transition()
@@ -58,33 +58,33 @@
           .transition()
             .duration(500)
             .attr("r", 20);
-        
+
         teamG
           .append("text")
             .style("text-anchor", "middle")
             .attr("y", 30)
             .text(d => d.team);
-        
+
         var dataKeys = Object.keys(incomingData[0])
           .filter(d => d !== "team" && d !== "region");
-        
+
         d3.select("#controls").selectAll("button.teams")
           .data(dataKeys).enter()
           .append("button")
             .on("click", buttonClick)
             .html(d => d);
-        
+
         function buttonClick(datapoint) {
           var maxValue = d3.max(incomingData, function(el) {
             return parseFloat(el[datapoint]);
           });
-          
+
           var tenColorScale = d3.scaleOrdinal()
-            .domain(["UEFA", "CONMEBOL", "CAF",  "AFC"])
+            .domain(["UEFA", "CONMEBOL", "CONCACAF",  "AFC"])
             .range(d3.schemeCategory10);
-          
+
           var radiusScale = d3.scaleLinear().domain([0,maxValue]).range([2,20]);
-          
+
           d3.selectAll("g.overallG").select("circle").transition().duration(1000)
               .style("fill", p => tenColorScale(p.region))
               .attr("r", p => radiusScale(p[datapoint ]));

--- a/chapter3/3_24.html
+++ b/chapter3/3_24.html
@@ -49,11 +49,11 @@
       <svg style="width:500px;height:500px;" ></svg>
     </div>
     <div id="controls" ></div>
-    
+
     <script>
-      
+
       d3.csv("../data/worldcup.csv", data => overallTeamViz(data));
-      
+
       function overallTeamViz(incomingData) {
         d3.select("svg")
           .append("g")
@@ -65,9 +65,9 @@
           .append("g")
             .attr("class", "overallG")
             .attr("transform", (d, i) =>`translate(${(i * 50)}, 0)`);
-        
+
         var teamG = d3.selectAll("g.overallG");
-        
+
         teamG
           .append("circle").attr("r", 0)
           .transition()
@@ -77,35 +77,35 @@
           .transition()
             .duration(500)
             .attr("r", 20);
-        
+
         teamG
           .append("text")
             .style("text-anchor", "middle")
             .attr("y", 30)
             .text(d => d.team);
-        
+
         d3.html("../resources/icon.svg", loadSVG);
-        
+
         function loadSVG(svgData) {
-          d3.selectAll("g").each(function() {
+          d3.selectAll("g.overallG").each(function() {
             var gParent = this;
             d3.select(svgData).selectAll("path").each(function() {
               gParent.appendChild(this.cloneNode(true));
             });
           });
-          
+
           d3.selectAll("g.overallG").each(function(d) {
             d3.select(this).selectAll("path").datum(d);
           });
-          
+
           var fourColorScale = d3.scaleOrdinal()
-            .domain(["UEFA", "CONMEBOL", "CAF", "AFC"])
+            .domain(["UEFA", "CONMEBOL", "CONCACAF", "AFC"])
             .range(["#5eafc6", "#FE9922", "#93C464", "#fcbc34" ]);
-          
+
           d3.selectAll("path")
               .style("fill", p => {
                 if (p) {
-                   fourColorScale(p.region);
+                   return fourColorScale(p.region);
                  }
               })
               .style("stroke", "black").style("stroke-width", "2px");


### PR DESCRIPTION
1) Fixed region label CAF -> CONCACAF in ordinal color scale in fig 3.16 and 3.24 to match worldcup data region labels in the `worldcup.csv` file.
(Note that "CAF" also appears in the corresponding part in the MEAP book.)

2) Added the `overallG` class in the first `g` elements selection of the `loadSVG` function  (`d3.selectAll("g")` to `d3.selectAll("g.overallG")`) to prevent cloning of an icon also for the master `g` element of the SVG. 